### PR TITLE
Fix lastmod date newline and timezone typo

### DIFF
--- a/_plugins/posts-lastmod-hook.rb
+++ b/_plugins/posts-lastmod-hook.rb
@@ -8,7 +8,7 @@ Jekyll::Hooks.register :posts, :post_init do |post|
 
   if commit_num.to_i > 1
     lastmod_date = `git log -1 --pretty="%ad" --date=iso "#{ post.path }"`
-    post.data['last_modified_at'] = lastmod_date
+    post.data['last_modified_at'] = lastmod_date.strip
   end
 
 end

--- a/_posts/2024-02-17-chirpyWebsite.md
+++ b/_posts/2024-02-17-chirpyWebsite.md
@@ -1,6 +1,6 @@
 ---
 title: Hello saleslab
-date: 2024-02-17 12:00:00 -500
+date: 2024-02-17 12:00:00 -0500
 categories: [sales]
 tags: [scripting, sales, land] #tags should always be lowercase
 ---


### PR DESCRIPTION
## Summary
- clean up newline in `posts-lastmod-hook.rb`
- fix timezone format typo in chirpyWebsite post

## Testing
- `jekyll` **not installed**